### PR TITLE
コンビネーションのバグ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # competitive_programming リポジトリ
 
-競技プログラミング ([AtCoder](https://atcoder.jp/) など) のソースコードなどを保存します。
+- 競技プログラミング ([AtCoder](https://atcoder.jp/) など) のソースコードなどを保存します。
+- ライセンス: パブリックドメイン (CC0 1.0)
+- バグや誤ったコメントが含まれている可能性があります。
 
 ## problem_answer
 

--- a/library/comb_gyakugen.cpp
+++ b/library/comb_gyakugen.cpp
@@ -95,7 +95,7 @@ struct Combi
     {
       return 0;
     }
-    else if (x > le) // O(min(y, x-y))
+    else if (x >= le) // O(min(y, x-y))
     {
       y = min(y, x - y);
       ll ans = 1;

--- a/library/comb_gyakugen.cpp
+++ b/library/comb_gyakugen.cpp
@@ -66,7 +66,7 @@ struct Combi
     {
       return 0;
     }
-    else if (x > le) // O(min(y, x-y))
+    else if (x >= le) // O(min(y, x-y))
     {
       y = min(y, x - y);
       ll ans = 1;

--- a/library/comb_gyakugen.py
+++ b/library/comb_gyakugen.py
@@ -55,7 +55,7 @@ def H(x, y):  # 重複組合せ、x + y < le にすることに注意
 def P(x, y):  # パーミュテーション (順列)
     if y < 0 or y > x:
         return 0
-    elif x > le:  # O(min(y, x-y))
+    elif x >= le:  # O(min(y, x-y))
         y = min(y, x-y)
         ans = 1
         for i in range(x, x-y, -1):

--- a/library/comb_gyakugen.py
+++ b/library/comb_gyakugen.py
@@ -36,7 +36,7 @@ for i in range(le-2, -1, -1):
 def C(x, y):  # コンビネーション (組合せ, 二項係数)
     if y < 0 or y > x:
         return 0
-    elif x > le:  # O(min(y, x-y))
+    elif x >= le:  # O(min(y, x-y))
         y = min(y, x-y)
         ans = 1
         for i in range(x, x-y, -1):

--- a/library/comb_gyakugen_smallmod.py
+++ b/library/comb_gyakugen_smallmod.py
@@ -76,11 +76,11 @@ def H(x, y):  # 重複組合せ、x + y < le にすることに注意
 def P(x, y):  # パーミュテーション (順列)
     if y < 0 or y > x:
         return 0
-    elif x > le:  # O(min(y, x-y))
+    elif x >= le:  # O(min(y, x-y))
         y = min(y, x-y)
         ans = PA[1]
         for i in range(x, x-y, -1):
-            ans = mul_pair(ans * PA[i])
+            ans = mul_pair(ans, int_to_pair(i))
         return pair_to_int(ans)
     else:  # O(1)
         return pair_to_int(mul_pair(M[x], MI[x-y]))

--- a/library/comb_gyakugen_smallmod.py
+++ b/library/comb_gyakugen_smallmod.py
@@ -63,7 +63,7 @@ def C(x, y):  # コンビネーション (組合せ, 二項係数)
         y = min(y, x-y)
         ans = PA[1]
         for i in range(x, x-y, -1):
-            ans = mul_pair(ans * PA[i])
+            ans = mul_pair(ans, int_to_pair(i))
         return pair_to_int(mul_pair(ans, MI[y]))
     else:  # O(1)
         return pair_to_int(mul_pair(mul_pair(M[x], MI[y]), MI[x-y]))

--- a/library/comb_gyakugen_smallmod.py
+++ b/library/comb_gyakugen_smallmod.py
@@ -59,7 +59,7 @@ for i in range(le-2, -1, -1):
 def C(x, y):  # コンビネーション (組合せ, 二項係数)
     if y < 0 or y > x:
         return 0
-    elif x > le:  # O(min(y, x-y))
+    elif x >= le:  # O(min(y, x-y))
         y = min(y, x-y)
         ans = PA[1]
         for i in range(x, x-y, -1):


### PR DESCRIPTION
## WHAT
- ライブラリのコンビネーション (二項係数) で、`x = le` である境界ケースでエラーになっていたので修正
- `comb_gyakugen_smallmod.py` では `x > le` の際にバグがあったので修正
- README にバグがあるかもしれないなどの説明を追記

## ToDo
- テストコードと、マージ時の自動テスト (CI) の追加