### PR TITLE
`dijkstra.py` に、入力が 1-indexed の場合の変換コードを追加

### DIFF
--- a/library/dijkstra.py
+++ b/library/dijkstra.py
@@ -3,6 +3,10 @@
 
 from heapq import heappop, heappush
 
+for i in range(len(C)):  # 入力が 1-indexed の場合
+    for j in range(2):
+        C[i][j] -= 1
+
 M = [[] for i in range(n)]
 for i in range(len(C)):
     M[C[i][0]].append((C[i][1], C[i][2]))


### PR DESCRIPTION
最近の AtCoder のコンテストは基本的に 1-indexed なので、ダイクストラ法のコードをコピペして使う際にもこれがあったほうが便利なため