### PR TITLE
`make_random_tree` デフォルトを 0-indexed にし、オプションとする

### DIFF
--- a/library/make_random_tree.py
+++ b/library/make_random_tree.py
@@ -1,15 +1,19 @@
-# n頂点の木をランダムに作成し、辺のリスト(1-indexed)を返す。
-def make_random_tree(n):
+def make_random_tree(n, one_indexed=False):
+    """n 頂点の木をランダムに作成し、辺のリストを返す。"""
     from random import randint, shuffle
 
     A = []
     for i in range(n - 1):
-        A.append([randint(1, i + 1), i + 2])
+        A.append([randint(0, i), i + 1])
     B = [i for i in range(n)]
     shuffle(B)
     for i in range(n - 1):
         for j in range(2):
-            A[i][j] = B[A[i][j] - 1] + 1
+            A[i][j] = B[A[i][j]]
         shuffle(A[i])
     shuffle(A)
+    if one_indexed:
+        for i in range(len(A)):
+            for j in range(2):
+                A[i][j] += 1
     return A


### PR DESCRIPTION
- 0-indexed で書いた方がコンテストで使いやすいため
- コードの可読性を上げるため

以下のように、簡易的に実行確認

```
>>> from library.make_random_tree import make_random_tree
>>> make_random_tree(5,True)
[[2, 5], [2, 4], [4, 3], [1, 5]]
>>> make_random_tree(5)
[[3, 0], [1, 4], [4, 0], [2, 0]]
>>> make_random_tree(5)
[[0, 3], [4, 3], [3, 2], [2, 1]]
```