### PR TITLE
トポロジカルソートに前処理部分のコードを追加

### DIFF
--- a/library/topological_sort.py
+++ b/library/topological_sort.py
@@ -1,4 +1,17 @@
-# INはその頂点を指している辺の本数のリスト
+n, m = map(int, input().split())
+C = [list(map(int, input().split())) for _ in range(m)]
+for i in range(len(C)):  # 入力が 1-indexed の場合
+    for j in range(2):
+        C[i][j] -= 1
+
+
+M = [[] for i in range(n)]
+IN = [0] * n  # その頂点を指している辺の本数のリスト
+
+for i in range(len(C)):
+    M[C[i][0]].append(C[i][1])
+    IN[C[i][1]] += 1
+
 
 S = []
 s = 0
@@ -13,3 +26,5 @@ while s < len(S):
         if IN[x] == 0:
             S.append(x)
     s += 1
+
+print(*S)


### PR DESCRIPTION
隣接リスト `M` などを作る前処理が終わっている前提のコードだったが、その部分もあった方が便利なため (不要な場合は使わなければよい)、追加