### PR TITLE
再帰なしDFSの更新

### DIFF
--- a/library/dfs_no_recursion.py
+++ b/library/dfs_no_recursion.py
@@ -22,40 +22,35 @@ for i in range(n - 1):
 
 P = [-1] * n  # iの親ノードの番号（最短路などの復元用）
 D = [-1] * n  # 始点からiまでの最短距離（兼訪問フラグ）
-DN = [1] * n  # i以深のノード総数（i自身も含める）
+DN = [-1] * n  # i以深のノード総数（i自身も含める）
 V_in = []  # 入った順に頂点番号を記録
 V_out = []  # 出た順に頂点番号を記録
 
 
-def dfs(i, d):
-    V_in.append(i)
-    for j in range(len(M[i]) - 1, -1, -1):
-        x = M[i][j]
-        if D[x] == -1:
-            D[x] = d + 1
+def dfs(i, next_ind):
+    if next_ind == len(M[i]):
+        V_out.append(i)
+        DN[i] = 1
+        for x in M[i]:
+            if P[x] == i:
+                DN[i] += DN[x]
+                print(i, x, DN[x], P[i])
+        ST.pop()
+    else:
+        x = M[i][next_ind]
+        if D[x] != -1:
+            ST[-1] = (i, next_ind + 1)
+        else:
+            D[x] = D[i] + 1
             P[x] = i
-            ST.append((x, d + 1))
-            end_count[i] += 1
-
-
-def dfs_end(i, p):  # その頂点を見終える際に行う処理
-    V_out.append(i)
-    for x in M[i]:
-        if x != p:
-            DN[i] += DN[x]
-    if p != -1:
-        end_count[p] -= 1
-    if end_count[p] == 0:
-        return p
-    return -1
+            V_in.append(x)
+            ST.append((x, 0))
 
 
 s = 0  # 始点の番号
 D[s] = 0
+V_in.append(s)
+
 ST = [(s, 0)]
-end_count = [0] * n  # 0になったら dfs_end を行う
 while len(ST) > 0:
-    i, d = ST.pop()
-    dfs(i, d)
-    while i != -1 and end_count[i] == 0:
-        i = dfs_end(i, P[i])
+    dfs(*ST[-1])

--- a/library/test/dfs_test.py
+++ b/library/test/dfs_test.py
@@ -1,6 +1,9 @@
 # dfs_no_recursion.py が dfs_tree_parent_distance_descendant.py と同様に動くかの確認
 
+import os
 import sys
+
+sys.path.append(os.pardir)  # 親ディレクトリ内のファイルをインポートするのに必要
 
 sys.setrecursionlimit(10 ** 9)  # Codeforcesでは350000程度に
 
@@ -9,35 +12,15 @@ def input():
     return sys.stdin.readline().strip()
 
 
-# n頂点の木をランダムに作成し、辺のリスト(1-indexed)を返す。
-def make_random_tree(n):
-    from random import randint, shuffle
+from make_random_graph import make_random_graph
 
-    A = []
-    for i in range(n - 1):
-        A.append([randint(1, i + 1), i + 2])
-    B = [i for i in range(n)]
-    shuffle(B)
-    for i in range(n - 1):
-        for j in range(2):
-            A[i][j] = B[A[i][j] - 1] + 1
-        shuffle(A[i])
-    shuffle(A)
-    return A
-
-
-n = 100
-C = make_random_tree(n)
-
-for i in range(len(C)):  # 入力が 1-indexed の場合
-    for j in range(2):
-        C[i][j] -= 1
-
+n = 20
+C = make_random_graph(n)
 
 M = [[] for i in range(n)]
-for i in range(n - 1):
+for i in range(len(C)):
     M[C[i][0]].append(C[i][1])
-    M[C[i][1]].append(C[i][0])  # 有向グラフの場合は削除！！
+    M[C[i][1]].append(C[i][0])
 
 # print(M)
 
@@ -69,44 +52,41 @@ dfs(s, 0)
 
 P_1 = [-1] * n  # iの親ノードの番号（最短路などの復元用）
 D_1 = [-1] * n  # 始点からiまでの最短距離（兼訪問フラグ）
-DN_1 = [1] * n  # i以深のノード総数（i自身も含める）
+DN_1 = [-1] * n  # i以深のノード総数（i自身も含める）
 V_in_1 = []  # 入った順に頂点番号を記録
 V_out_1 = []  # 出た順に頂点番号を記録
+# print(DN_1)
 
 
-def dfs_1(i, d):
-    V_in_1.append(i)
-    for j in range(len(M[i]) - 1, -1, -1):
-        x = M[i][j]
-        if D_1[x] == -1:
-            D_1[x] = d + 1
+def dfs_1(i, next_ind):
+    if next_ind == len(M[i]):
+        V_out_1.append(i)
+        DN_1[i] = 1
+        for x in M[i]:
+            if P_1[x] == i:
+                DN_1[i] += DN_1[x]
+                # print(i, x, DN_1[x], P_1[i])
+        ST.pop()
+    else:
+        x = M[i][next_ind]
+        if D_1[x] != -1:
+            ST[-1] = (i, next_ind + 1)
+        else:
+            D_1[x] = D_1[i] + 1
             P_1[x] = i
-            ST.append((x, d + 1))
-            end_count[i] += 1
-
-
-def do_end(i, p):
-    V_out_1.append(i)
-    for x in M[i]:
-        if x != p:
-            DN_1[i] += DN_1[x]
-    if p != -1:
-        end_count[p] -= 1
-    if end_count[p] == 0:
-        return p
-    return -1
+            V_in_1.append(x)
+            ST.append((x, 0))
 
 
 s = 0  # 始点の番号
 D_1[s] = 0
+V_in_1.append(s)
 ST = [(s, 0)]
-end_count = [0] * n
 while len(ST) > 0:
-    i, d = ST.pop()
-    dfs_1(i, d)
-    while i != -1 and end_count[i] == 0:
-        i = do_end(i, P_1[i])
+    dfs_1(*ST[-1])
 
+# print(DN)
+# print(DN_1)
 assert P == P_1
 assert D == D_1
 assert DN == DN_1


### PR DESCRIPTION
木でないグラフであってもDFSで木を作りながら探索すること (例: DFS木 ([説明](https://atcoder.jp/contests/abc251/editorial/3967)) の作成) が、現在の再帰なしDFSのコードではできていない状態だったので対応 (再帰ありDFSではできる)
テストコードも、木でない一般のグラフでテストするよう更新

AC確認: https://atcoder.jp/contests/abc294/submissions/39885840