### PR TITLE
セグメントツリー高速化

### DIFF
--- a/library/segment_tree.py
+++ b/library/segment_tree.py
@@ -18,6 +18,7 @@ class Segtree:
         i = 1
         while i < n:
             i *= 2
+        self.op = op
         self.e = e()
         self.tree = [self.e for _ in range(2 * i - 1)]
         self.size2 = i
@@ -50,12 +51,12 @@ class Segtree:
         while a < b:
             # a が右ノードならば、その値を演算結果に結合する
             if a % 2 == 1:
-                ans = op(ans, self.tree[a - 1])
+                ans = self.op(ans, self.tree[a - 1])
                 a += 1
             a //= 2
             # b が左ノードならば、その値を演算結果に結合する
             if b % 2 == 1:
-                ans = op(ans, self.tree[b - 2])
+                ans = self.op(ans, self.tree[b - 2])
             b //= 2
         return ans
 

--- a/library/segment_tree.py
+++ b/library/segment_tree.py
@@ -60,6 +60,10 @@ class Segtree:
             b //= 2
         return ans
 
+    def all_prod(self):
+        """全区間の演算結果を返す。O(1)"""
+        return self.tree[0]
+
 
 # 以下は抽象化前のもの
 

--- a/library/segment_tree.py
+++ b/library/segment_tree.py
@@ -36,21 +36,28 @@ class Segtree:
             j = (j - 1) // 2
             self.tree[j] = op(self.tree[2 * j + 1], self.tree[2 * j + 2])
 
-    def prod(self, a, b, k=0, ll=0, rr=None):
+    def prod(self, a, b):
         """
         区間 [a, b) の演算結果を返す。O(log n)
-        k は今見ている内部 index の番号、[ll, rr) は self.tree[k] が表す区間。
+        並立する子ノード 2 個のうち index の小さい方 = 0-indexed で奇数のノードを左ノード、
+        それ以外 (根を含む) = 0-indexed で偶数のノードを右ノードとすると、
+        任意の区間は「0 個以上の右ノード」と「0 個以上の左ノード」をこの順に繋げたもので表せる。
+        そのノード列を葉から根に向かって求めながら、演算していく。
         """
-        if rr is None:
-            rr = self.size2
-        if rr <= a or b <= ll:
-            return self.e
-        elif a <= ll and rr <= b:
-            return self.tree[k]
-        else:
-            vl = self.prod(a, b, 2 * k + 1, ll, (ll + rr) // 2)
-            vr = self.prod(a, b, 2 * k + 2, (ll + rr) // 2, rr)
-            return op(vl, vr)
+        ans = self.e
+        a += self.size2
+        b += self.size2
+        while a < b:
+            # a が右ノードならば、その値を演算結果に結合する
+            if a % 2 == 1:
+                ans = op(ans, self.tree[a - 1])
+                a += 1
+            a //= 2
+            # b が左ノードならば、その値を演算結果に結合する
+            if b % 2 == 1:
+                ans = op(ans, self.tree[b - 2])
+            b //= 2
+        return ans
 
 
 # 以下は抽象化前のもの

--- a/library/segment_tree.py
+++ b/library/segment_tree.py
@@ -49,12 +49,12 @@ class Segtree:
         a += self.size2
         b += self.size2
         while a < b:
-            # a が右ノードならば、その値を演算結果に結合する
+            # a-1 が右ノードならば、その値を演算結果に結合する
             if a % 2 == 1:
                 ans = self.op(ans, self.tree[a - 1])
                 a += 1
             a //= 2
-            # b が左ノードならば、その値を演算結果に結合する
+            # b-2 が左ノードならば、その値を演算結果に結合する
             if b % 2 == 1:
                 ans = self.op(ans, self.tree[b - 2])
             b //= 2


### PR DESCRIPTION
## WHY

ABC339-EでTLEした。
[1] https://atcoder.jp/contests/abc339/submissions/49949436
同じPyPyでACしている人もいる。
[2] https://atcoder.jp/contests/abc339/submissions/49989576
セグ木以外の部分は単純でほぼ共通なため、セグ木の実装に改善の余地がありそう。

## WHAT
上記 [2] の提出を参考に、`prod` を書き直した。
根から葉でなく、葉から根へ、欲しいノードを探していくことで、while 内を繰り返す回数が葉数を $n$ として必ず $2(\log_{2}{n} + 1)$ 回になるため、多くの場合で探索回数が少なくなる。
ただ、全区間や前半分の区間を指定した場合は以前より多くなる。
前半分の区間などはレアケースだが (ただし Codeforces などではハックされうるかも)、全区間の指定を繰り返すことはありそうなので、対策として `all_prod` を追加した。
再帰を使わないことでも速くなっているはず。
また `op` を class に持たせるようにした。(これでも少し速くなったかも)

## AC確認

- prod改善、718ms: https://atcoder.jp/contests/abc339/submissions/50307702
- prod改善+opを持たせる、531ms: https://atcoder.jp/contests/abc339/submissions/50313132

## 参考

遅延セグ木では `prod` の際に、遅延させていた評価を根から葉へ順次送る必要があるため、この高速化はできなそう。