### PR TITLE
遅延セグ木の関数の修正

### DIFF
--- a/library/lazy_segment_tree.py
+++ b/library/lazy_segment_tree.py
@@ -1,29 +1,29 @@
-# 以下の op, e, mapping, composition, id は、区間を最小値で更新し、区間和を求めるような遅延評価セグメント木を作る場合の例。
+# 以下の op, e, mapping, composition, id は、区間に x を加算し、区間最小値を求める (Range Add Range Min) ような遅延評価セグメント木を作る場合の例。
 
 
 def op(x0, x1):
     # 木に入っているもの x0, x1 の演算を返すようにする (演算は結合法則を満たす必要があるが、可換でなくてもよい) 。
-    return x0 + x1
+    return min(x0, x1)
 
 
 def e():
     # op の単位元を返す。
-    return 0
+    return float("inf")
 
 
 def mapping(x, f):
     # 木に入っているもの x に関数 f を作用させる。
-    return min(x, f)
+    return x + f
 
 
 def composition(f0, f1):
     # 関数 f0 と f1 の合成 (f0 をしてから f1 をする、という順序) (演算は結合法則を満たす必要があるが、可換でなくてもよい) 。
-    return min(f0, f1)
+    return f0 + f1
 
 
 def id():
     # composition の単位元を返す。
-    return float("inf")
+    return 0
 
 
 class LazySegtree:

--- a/library/lazy_segment_tree.py
+++ b/library/lazy_segment_tree.py
@@ -42,6 +42,9 @@ class LazySegtree:
             size_log += 1
         self.e = e()
         self.id = id()
+        self.mapping = mapping
+        self.composition = composition
+        self.op = op
         self.tree = [self.e for _ in range(2 * i - 1)]
         self.lazy = [self.id for _ in range(2 * i - 1)]
         self.size2 = i
@@ -59,9 +62,9 @@ class LazySegtree:
         if lazy_k == self.id:
             return
         if k < self.size2 - 1:
-            self.lazy[2 * k + 1] = composition(self.lazy[2 * k + 1], lazy_k)
-            self.lazy[2 * k + 2] = composition(self.lazy[2 * k + 2], lazy_k)
-        self.tree[k] = mapping(self.tree[k], lazy_k)
+            self.lazy[2 * k + 1] = self.composition(self.lazy[2 * k + 1], lazy_k)
+            self.lazy[2 * k + 2] = self.composition(self.lazy[2 * k + 2], lazy_k)
+        self.tree[k] = self.mapping(self.tree[k], lazy_k)
         self.lazy[k] = self.id
 
     def update(self, i, x):
@@ -76,7 +79,7 @@ class LazySegtree:
         # 下から上まで更新
         while j > 0:
             j = (j - 1) // 2
-            self.tree[j] = op(self.tree[2 * j + 1], self.tree[2 * j + 2])
+            self.tree[j] = self.op(self.tree[2 * j + 1], self.tree[2 * j + 2])
 
     def apply(self, a, b, x, k=0, ll=0, rr=None):
         """
@@ -87,12 +90,12 @@ class LazySegtree:
             rr = self.size2
         self._eval(k)
         if a <= ll and rr <= b:
-            self.lazy[k] = composition(self.lazy[k], x)
+            self.lazy[k] = self.composition(self.lazy[k], x)
             self._eval(k)
         elif a < rr and ll < b:  # [ll, rr) が [a, b) に含まれないが、共通部分はある場合
             self.apply(a, b, x, 2 * k + 1, ll, (ll + rr) // 2)
             self.apply(a, b, x, 2 * k + 2, (ll + rr) // 2, rr)
-            self.tree[k] = op(self.tree[2 * k + 1], self.tree[2 * k + 2])
+            self.tree[k] = self.op(self.tree[2 * k + 1], self.tree[2 * k + 2])
 
     def prod(self, a, b, k=0, ll=0, rr=None):
         """
@@ -109,4 +112,4 @@ class LazySegtree:
         else:
             vl = self.prod(a, b, 2 * k + 1, ll, (ll + rr) // 2)
             vr = self.prod(a, b, 2 * k + 2, (ll + rr) // 2, rr)
-            return op(vl, vr)
+            return self.op(vl, vr)

--- a/library/lazy_segment_tree.py
+++ b/library/lazy_segment_tree.py
@@ -1,4 +1,4 @@
-# 以下の op, e, mapping, composition, id は、区間に x を加算し、区間最小値を求める (Range Add Range Min) ような遅延評価セグメント木を作る場合の例。
+# 以下の op, e, mapping, composition, id は、区間に加算し、区間最小値を求める (Range Add Range Min) ような遅延評価セグメント木を作る場合の例。
 
 
 def op(x0, x1):

--- a/library/test/lazy_segment_tree_test_new.py
+++ b/library/test/lazy_segment_tree_test_new.py
@@ -1,0 +1,48 @@
+import sys
+
+sys.path.append("../")
+from library.lazy_segment_tree import LazySegtree
+
+inf = float("inf")
+length = 10
+seg = LazySegtree(length)
+
+# update の確認
+seg.update(0, 1)
+seg.update(2, -1)
+expected = [1, inf, -1, inf, inf, inf, inf, inf, inf, inf]
+
+assert [seg[i] for i in range(length)] == expected
+
+# prod の確認
+for le in range(length):
+    for ri in range(le, length):
+        if le == ri:
+            assert seg.prod(le, ri) == inf
+        else:
+            assert seg.prod(le, ri) == min(expected[le:ri])
+
+for i in range(length):
+    if seg[i] == inf:
+        seg.update(i, 10)
+
+expected = [1, 10, -1, 10, 10, 10, 10, 10, 10, 10]
+
+assert [seg[i] for i in range(length)] == expected
+
+# apply の確認
+seg.apply(0, 6, 10)
+seg.apply(4, 9, -10)
+seg.apply(3, 3, -10000)
+seg.update(5, -100)
+expected = [11, 20, 9, 20, 10, -100, 0, 0, 0, 10]
+
+assert [seg[i] for i in range(length)] == expected
+
+
+for le in range(length):
+    for ri in range(le, length):
+        if le == ri:
+            assert seg.prod(le, ri) == inf
+        else:
+            assert seg.prod(le, ri) == min(expected[le:ri])


### PR DESCRIPTION
## WHY

[Meta Hacker Cup 2023 Round 1 の D 問題](https://www.facebook.com/codingcompetitions/hacker-cup/2023/round-1/problems/D)を解いた際に、遅延評価セグメント木がうまく動かないことに気付いた。
あとで見てみたところ、現在例として書いている関数や単位元 (区間を最小値で更新する・区間和を求める操作) が、作用付きモノイドの条件を満たしていないことがわかった。( $\min(f, x+y) = \min(f, x) + \min(f, y)$ は常には成り立たない) [1]
遅延セグ木本体には問題はなさそう。

## WHAT

- 関数や単位元を、区間に加算する・区間最小値を求める (Range Add Range Min) ものに書き換えた
  - これなら作用付きモノイドになる ( $f + \min(x, y) = \min(f + x, f + y)$ ) [2]
- `op` などの関数をクラスに持たせるようにした (少し速くなるかも)
- テストコードで想定通りに動くことを確認

## 参考
 
- [1] https://chat.openai.com/c/a89ddeeb-9b16-4d27-b683-c0a0194f9020
- [2] https://drken1215.hatenablog.com/entry/2023/10/06/020254
- https://algo-logic.info/segment-tree/
- [AtCoder Library](https://atcoder.jp/posts/517) の遅延セグ木のドキュメント