### PR TITLE
ハッシュ衝突攻撃対策をした辞書クラス追加

### DIFF
--- a/library/protected_dict.py
+++ b/library/protected_dict.py
@@ -1,0 +1,33 @@
+from random import randint
+
+
+class ProtectedDict(dict):
+    """
+    キーにランダムな値を足してから辞書に追加することで、キーのハッシュ衝突攻撃を防ぐ辞書クラス。
+    参考: https://codeforces.com/blog/entry/101817
+    """
+
+    def __init__(self):
+        self.salt = randint(1, 10**8)
+        super().__init__()
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key + self.salt, value)
+
+    def __getitem__(self, key):
+        return super().__getitem__(key + self.salt)
+
+    def __delitem__(self, key):
+        super().__delitem__(key + self.salt)
+
+    def __contains__(self, key):
+        return super().__contains__(key + self.salt)
+
+    def keys(self) -> set:
+        return set(key - self.salt for key in super().keys())
+
+    def values(self) -> set:
+        return set(super().values())
+
+    def items(self) -> set:
+        return set((key - self.salt, value) for key, value in super().items())

--- a/library/test/protected_dict_test.py
+++ b/library/test/protected_dict_test.py
@@ -1,0 +1,26 @@
+import sys
+
+sys.path.append("../")
+from library.protected_dict import ProtectedDict
+
+D = ProtectedDict()
+
+D[0] = 1
+D[1] = 2
+
+assert D[0] == 1
+assert D[1] == 2
+assert 0 in D
+assert 1 in D
+assert 2 not in D
+
+D[0] = 3
+assert D[0] == 3
+
+del D[0]
+assert 0 not in D
+
+D[0] = 1
+assert D.keys() == {0, 1}
+assert D.values() == {1, 2}
+assert D.items() == {(0, 1), (1, 2)}


### PR DESCRIPTION
## WHY

CodeforcesでPythonの辞書を使った解法に対して、故意に整数キーをハッシュ衝突させ、追加・更新に O(既存のキー数) かかるようにしTLEさせるハックケースが見られる。(AtCoderのテストケースでは多分まだ出ていないが、今後出てくるかもしれない)
参考
[1] https://codeforces.com/blog/entry/101817
[2] https://qiita.com/recuraki/items/8dc7d91e83cace002117
[3] https://x.com/mo124121/status/1692163079839371365?s=20

これに対し、ランダムな整数を決めておき、本来のキーに足し引き (または xor) したものをキーとして扱う対策がある。
ただ、その都度足し引きするのは面倒なので、クラスを作っておきたい。

## WHAT

dict を継承し、キーに対策したうえで競プロで使う基本的なことをできるようにした `ProtectedDict` を作成した。
ランダムな整数の候補数は、小さすぎるとハックケースが作りやすく、大きすぎると遅くなりそうなので、 $10^8$ とした。
AtCoder のコードテスト (PyPy 3.10-v7.3.12) で以下のコードを試したら、dict で 1400 ms、`ProtectedDict` で 1517 ms と、そこまで遅くならなかった。

```python
D = ProtectedDict()
# D = dict()
for i in range(10**7):
    D[i] = i
    D[i] += i
```

## 参考

これで遅い場合は、その都度足し引きするのが良い。
他には、整数を文字列にする、int をラップするなどの方法もある ([1] のコメント欄参照)。

特殊メソッドまとめ: https://qiita.com/yoshi-kin/items/26fa4194ee7a726d685c